### PR TITLE
Grader refactor

### DIFF
--- a/parsons.js
+++ b/parsons.js
@@ -85,7 +85,11 @@
           mainmod,
           result = {'variables': {}},
           varname;
-      Sk.configure( { output: function(str) { output += str; } } );
+      // configure Skulpt
+      Sk.execLimit = parson.options.exec_limit || 2500; // time limit for the code to run
+      Sk.configure( { output: function(str) { output += str; },
+          python3: parson.options.python3 || false
+      } );
       try {
         mainmod = Sk.importMainWithBody("<stdin>", false, code);
       } catch (e) {
@@ -229,7 +233,7 @@
     }
 
     // configuration for Skulpt
-    Sk.execLimit = 2500; // time limit for the code to run
+    Sk.execLimit = parson.options.exec_limit || 2500; // time limit for the code to run
     Sk.configure({output: console?console.log:function() {},
                   read: builtinRead,
                   python3: parson.options.python3 || false


### PR DESCRIPTION
- Added back old variable-value-based grader because needed exercises without function definitions.
- Moved graders to their own objects away from ParsonWidget:
  - `VariableCheckGrader` executes code and checks variable values after execution
  - `UnitTestGrader` executes unit tests
  - `LineBasedGrader` is the original grader based on line order comparison (note: I did not fix the existing bugs with same lines in this grader)
