### PR TITLE
Refactored python execution to be in only one place

### DIFF
--- a/parsons.js
+++ b/parsons.js
@@ -149,7 +149,6 @@
   // formats a Skulpt variable to the corresponding Python value
   VariableCheckGrader.prototype.formatVariableValue = function(varValue) {
     var varType = typeof varValue;
-    console.log(varValue, varType);
     if (varType === "undefined" || varValue === null) {
       return "None";
     } else if (varType === "string") { // show strings in quotes


### PR DESCRIPTION
Python execution is now only in VariableCheckGrader._python_exec and the same implementation is also used by the UnittestGrader.

This commit also fixes some bugs in the python-executing graders, namely:
- some variable types not formatted properly in test results
- non-existing variables no longer crash the grading
