### PR TITLE
Fix coloring of variable values in variable checker feedback

### DIFF
--- a/parsons.css
+++ b/parsons.css
@@ -70,7 +70,7 @@ li.correctPosition, .testcase.pass {
 .testcase .msg { font-weight: bold; }
 .testcase .error { color: red;}
 .testcase .feedback { font-weight: bolder;}
-.testcase.fail .expected, .testcase.fail .actual { 
+.testcase .fail .expected, .testcase .fail .actual {
     color: red; 
     font-weight: bolder;
 }

--- a/parsons.js
+++ b/parsons.js
@@ -244,18 +244,25 @@
         log_entry.type = "assertion";
         log_entry.variables = {};
         for (var j = 0; j < variables.length; j++) {
-          var variable = variables[j];
+          var variable = variables[j],
+              variableSuccess;
           if (variable === "__output") { // checking output of the program
             expected_value = testdata.expected;
             actual_value = res._output;
-            testcaseFeedback += parson.translations.unittest_output_assertion(expected_value, actual_value);
+            variableSuccess = (actual_value == expected_value); // should we do a strict test??
+            testcaseFeedback += "<div class='" + (variableSuccess?"pass":"fail") + "'>";
+            testcaseFeedback += parson.translations.unittest_output_assertion(expected_value, actual_value) +
+                                "</div>";
           } else {
             expected_value = that.formatVariableValue(expectedVals[variable]);
             actual_value = that.formatVariableValue(res.variables[variable]);
-            testcaseFeedback += parson.translations.variabletest_assertion(variable, expected_value, actual_value) + "<br/>";
+            variableSuccess = (actual_value == expected_value);  // should we do a strict test??
+            testcaseFeedback += "<div class='" + (variableSuccess?"pass":"fail") + "'>";
+            testcaseFeedback += parson.translations.variabletest_assertion(variable, expected_value, actual_value) +
+                                "</div>";
           }
           log_entry.variables[variable] = {expected: expected_value, actual: actual_value};
-          if (actual_value != expected_value) { // should we do a strict test??
+          if (!variableSuccess) {
             success = false;
           }
         }


### PR DESCRIPTION
With the variable test grader, variables with correct values were highlighted red if another variable in the testcase had an incorrect value. This fixes it so that only variables with incorrect values are in red.

You can test this with the examples/toggle-variable-grader-example.html file and creating solution x = y.
